### PR TITLE
Let ZAQ_PREFIXES to be set before sourcing

### DIFF
--- a/zsh-autoquoter.zsh
+++ b/zsh-autoquoter.zsh
@@ -1,4 +1,4 @@
-declare -a ZAQ_PREFIXES=()
+declare -ga ZAQ_PREFIXES
 
 _zaq_count_args() {
   echo $#


### PR DESCRIPTION
Hi! This change allows you to set `ZAQ_PREFIXES` before sourcing the plugin. So in your `.zshrc`, you could write:

```zsh
ZAQ_PREFIXES=('git commit -m')
source /path/to/zsh-autoquoter.zsh
```

instead of:

```zsh
source /path/to/zsh-autoquoter.zsh
ZAQ_PREFIXES=('git commit -m')
```

I selfishly want this because the way I've organized my `.zshrc`.